### PR TITLE
Add simplest implementation of Community map

### DIFF
--- a/pyspain_web/static/web/css/main.css
+++ b/pyspain_web/static/web/css/main.css
@@ -272,3 +272,8 @@ section .pagination .step-links .current {
     font-size: 12px;
     color: #777;
 }
+
+#map {
+    width: 70vw;
+    height:500px;
+}

--- a/pyspain_web/templates/web/community-events.jinja
+++ b/pyspain_web/templates/web/community-events.jinja
@@ -3,6 +3,8 @@
 {% block body %}
 <div class="community-events-page">
     <section class="community-events">
+        {% include "web/community-map.jinja" %}
+        <hr>
         <h1>Calendario de eventos Python en España</h2>
 
         {% for entry in page.object_list %}

--- a/pyspain_web/templates/web/community-map.jinja
+++ b/pyspain_web/templates/web/community-map.jinja
@@ -1,0 +1,40 @@
+<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.5/leaflet.css" />
+<script src="http://cdn.leafletjs.com/leaflet-0.7.5/leaflet.js"></script>
+<script   src="http://code.jquery.com/jquery-3.1.1.slim.min.js"   integrity="sha256-/SIrNqv8h6QGKDuNoLGA4iret+kyesCkHGzVUUV0shc="   crossorigin="anonymous"></script>
+
+<h1>Mapa de Comunidades Python en España</h2>
+<div id="map"></div>
+
+<script>
+    var map = L.map('map',{
+    center: [36.014, -5.120],
+    zoom: 5
+    });
+    L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+    attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+    }).addTo(map);
+
+function addLocation(loc_data) {
+    var title = loc_data[2];
+    var link = loc_data[3];
+  L.marker([loc_data[0], loc_data[1]]).bindPopup(`${title} <a target="_blank" href=${link}>Link.</a>`).addTo(map);
+}
+
+
+var locations = [
+[38.01348, -1.17376, 'Python Meetup Murcia', 'http://www.meetup.com/es-ES/Meetup-de-Python-en-Murcia/'],
+[40.4300, -3.6526, 'Python Madrid', 'http://www.python-madrid.es/'],
+[38.01348, -1.17376, 'Python Murcia', 'http://www.meetup.com/es-ES/Meetup-de-Python-en-Murcia/'],
+[40.43, -3.6526, 'Python Madrid', 'http://www.python-madrid.es/'],
+[42.1986, -8.7726, 'Python Vigo', 'http://www.python-vigo.es/'],
+[36.7644, -4.4242, 'Python Málaga', 'http://www.meetup.com/malaga-python/'],
+[39.4227, -0.3525, 'Python Valencia', 'http://www.meetup.com/es-ES/Python-Valencia-Meetup/'],
+[41.3929, 2.1404, 'PyBCN', 'http://pybcn.org/'],
+[39.6602, 2.9862, 'Python Mallorca', 'http://www.meetup.com/es-ES/Mallorca-Python-Meetup/'],
+[37.3766, -5.926, 'Python Sevilla', 'http://www.meetup.com/es-ES/Python-Sevilla/'],
+[41.692, -0.9271, 'PythonZaragoza', 'https://plus.google.com/communities/103281359456269063508'],
+[37.1809, -3.5983, 'Python Granada', 'http://www.python-granada.es/'],
+]
+
+locations.forEach(addLocation)
+</script>

--- a/pyspain_web/templates/web/community-map.jinja
+++ b/pyspain_web/templates/web/community-map.jinja
@@ -25,7 +25,6 @@ var locations = [
 [38.01348, -1.17376, 'Python Meetup Murcia', 'http://www.meetup.com/es-ES/Meetup-de-Python-en-Murcia/'],
 [40.4300, -3.6526, 'Python Madrid', 'http://www.python-madrid.es/'],
 [38.01348, -1.17376, 'Python Murcia', 'http://www.meetup.com/es-ES/Meetup-de-Python-en-Murcia/'],
-[40.43, -3.6526, 'Python Madrid', 'http://www.python-madrid.es/'],
 [42.1986, -8.7726, 'Python Vigo', 'http://www.python-vigo.es/'],
 [36.7644, -4.4242, 'Python Málaga', 'http://www.meetup.com/malaga-python/'],
 [39.4227, -0.3525, 'Python Valencia', 'http://www.meetup.com/es-ES/Python-Valencia-Meetup/'],

--- a/pyspain_web/views.py
+++ b/pyspain_web/views.py
@@ -4,7 +4,7 @@ from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
 from django.db.models import get_model
 from django.shortcuts import get_object_or_404
 
-from pyspain.views import GenericView, GenericTemplateView
+from pyspain.views import GenericTemplateView
 from pyspain_web import utils
 
 


### PR DESCRIPTION
Este branch contiene la implementación mas simple de un mapa con las comunidades python en españa. 

Para no añádir jquery o similares solo para el mapa, los datos de las localizaciones están directamente hardcoded en la plantilla (feo pero simple).

Los datos de las comunidades que he encontrado los he puesto [aquí](https://docs.google.com/spreadsheets/d/16rUBrA91jxotyd_Eak2-F911OgHjlwOxTdD809dw_e8/edit?usp=sharing) . Feel free to add to the list!

Saludetes,
Manu