### PR TITLE
CDN sobre HTTPS

### DIFF
--- a/src/pyspain_web/templates/web/community-map.jinja
+++ b/src/pyspain_web/templates/web/community-map.jinja
@@ -1,6 +1,6 @@
-<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.5/leaflet.css" />
-<script src="http://cdn.leafletjs.com/leaflet-0.7.5/leaflet.js"></script>
-<script   src="http://code.jquery.com/jquery-3.1.1.slim.min.js"   integrity="sha256-/SIrNqv8h6QGKDuNoLGA4iret+kyesCkHGzVUUV0shc="   crossorigin="anonymous"></script>
+<link rel="stylesheet" href="//cdn.leafletjs.com/leaflet-0.7.5/leaflet.css" />
+<script src="//cdn.leafletjs.com/leaflet-0.7.5/leaflet.js"></script>
+<script   src="//code.jquery.com/jquery-3.1.1.slim.min.js"   integrity="sha256-/SIrNqv8h6QGKDuNoLGA4iret+kyesCkHGzVUUV0shc="   crossorigin="anonymous"></script>
 
 <h1>Mapa de Comunidades Python en España</h2>
 <div id="map"></div>


### PR DESCRIPTION
Necesita que se pruebe sobre HTTPS.

Usando `src="//cdn` en lugar de `src="http://cdn` soluciona la mayoría de problemas de contenido bloqueado, cargando directamente vía HTTP o HTTPS el recurso según se necesite.

Técnicamente este pull soluciona la issue #8 