### PR TITLE
Añadido pytest como framework de pruebas

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ django-jinja==0.23
 south==0.8.4
 markdown==2.3.1
 gunicorn==19.1.1
+pytest==3.0.7
+pytest-django==2.9.1

--- a/src/pytest.ini
+++ b/src/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = settings.common
+python_files = tests.py test_*.py *_tests.py
+

--- a/src/test_version.py
+++ b/src/test_version.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import pytest
+import django
+
+def test_current_django_version():
+    assert django.VERSION >= (1, 6, 1)
+
+
+if __name__ == '__main__':
+    pytest.main()


### PR DESCRIPTION
- Se han añadido `pytest` y `pytest-django` en el fichero `requeriments.txt`
- Recomiendo también `pytest-sugar`, pero no lo incluyo porque no es imprescindible
- Hay un test simplón, `test_version.py`, solo para comprobar que pytest funcione correctamente