### PR TITLE
Add Python Girona to Associations Map

### DIFF
--- a/src/pyspain_web/templates/web/community-map.jinja
+++ b/src/pyspain_web/templates/web/community-map.jinja
@@ -40,6 +40,7 @@ var locations = [
 [28.4811, -16.3227, 'Python Canarias', 'http://pythoncanarias.es/'],
 [38.3453, -0.4831, 'Python Alicante', 'https://twitter.com/python_alc'],
 [43.2918, -1.9889, 'Python San Sebastián', 'http://pyss.org/'],
+[41.9830495, 2.8245813, 'Python Girona', 'http://www.meetup.com/PythonGirona/'],
 ]
 
 locations.forEach(addLocation)


### PR DESCRIPTION
It extend the list of locations adding **Python Girona** and the related *meetup* site as a landing page.